### PR TITLE
Write the panic message to the serial output

### DIFF
--- a/backend/crates/kartoffel/Cargo.toml
+++ b/backend/crates/kartoffel/Cargo.toml
@@ -3,6 +3,12 @@ name = "kartoffel"
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = ["serial-panic"]
+
+# Enables printing of the panic message to the serial port
+serial-panic = []
+
 [dependencies]
 spin.workspace = true
 talc.workspace = true

--- a/backend/crates/kartoffel/src/panic.rs
+++ b/backend/crates/kartoffel/src/panic.rs
@@ -1,10 +1,18 @@
+use core::fmt::Write;
 use core::panic::PanicInfo;
+
+use crate::SerialOutput;
 
 #[allow(dead_code)]
 #[allow(clippy::empty_loop)]
 #[cfg_attr(target_arch = "riscv64", panic_handler)]
-fn panic(_: &PanicInfo) -> ! {
+fn panic(i: &PanicInfo) -> ! {
+    let mut output = SerialOutput;
+
+    let _ = write!(&mut output, "\n- KERNEL PANIC -\n");
+    let _ = write!(&mut output, "{}", i);
+
     loop {
-        //
+        // Loop forever
     }
 }

--- a/backend/crates/kartoffel/src/panic.rs
+++ b/backend/crates/kartoffel/src/panic.rs
@@ -1,7 +1,6 @@
+use crate::SerialOutput;
 use core::fmt::Write;
 use core::panic::PanicInfo;
-
-use crate::SerialOutput;
 
 #[allow(dead_code)]
 #[allow(clippy::empty_loop)]
@@ -9,8 +8,10 @@ use crate::SerialOutput;
 fn panic(i: &PanicInfo) -> ! {
     let mut output = SerialOutput;
 
-    let _ = write!(&mut output, "\n- KERNEL PANIC -\n");
-    let _ = write!(&mut output, "{}", i);
+    // Only print the panic message if the `serial-panic` feature is enabled.
+    // Allows it to be disabled for smaller binaries.
+    #[cfg(feature = "serial-panic")]
+    let _ = write!(&mut output, "\n{}", i);
 
     loop {
         // Loop forever

--- a/backend/crates/kartoffel/src/serial.rs
+++ b/backend/crates/kartoffel/src/serial.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::{wri, MEM_SERIAL};
 use alloc::string::String;
 
@@ -98,5 +100,30 @@ impl SerialWritable for String {
 impl SerialWritable for SerialControlCode {
     fn write(self) {
         wri(MEM_SERIAL, 0, self.encode());
+    }
+}
+
+/// A dummy struct for writing formatted strings to the serial port.
+///
+/// Implements `fmt::Write` trait, so you can use it with `write!` to write
+/// formatted strings to the serial port, totally without any allocations.
+///
+/// # Example
+///
+/// ```no_run
+/// use kartoffel::*;
+/// use core::fmt::Write;
+///
+/// let mut serial = SerialOutput;
+/// write!(&mut serial, "Hello, {}!", "world").unwrap();
+/// ```
+pub struct SerialOutput;
+
+impl fmt::Write for SerialOutput {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            c.write();
+        }
+        Ok(())
     }
 }

--- a/backend/crates/kartoffel/src/serial.rs
+++ b/backend/crates/kartoffel/src/serial.rs
@@ -1,7 +1,6 @@
-use core::fmt;
-
 use crate::{wri, MEM_SERIAL};
 use alloc::string::String;
+use core::fmt;
 
 /// Writes a character or a string to the serial port.
 ///


### PR DESCRIPTION
This PR adds the `SerialOutput` unit struct which implements `fmt::Write` to allow writing formatted string directly to the serial output without allocating and uses it to write the panic message.