### PR TITLE
Update is_pos_legal to have an air-gap of 1 for potential spawns

### DIFF
--- a/app/crates/kartoffels-world/src/bots/systems/spawn.rs
+++ b/app/crates/kartoffels-world/src/bots/systems/spawn.rs
@@ -146,6 +146,13 @@ fn is_pos_legal(
     objs: &Objects,
     pos: IVec2,
 ) -> bool {
+    for x in -1..1 {
+        for y in -1..1 {
+            if bots.lookup_at(pos + IVec2::new(x, y)).is_some() {
+                return false;
+            }
+        }
+    }
     map.get(pos).is_floor()
         && bots.lookup_at(pos).is_none()
         && objs.lookup_at(pos).is_none()


### PR DESCRIPTION
This closes #56 with a simple check for potential spawns to have no bots in a 3x3 area surrounding the potential spawn. 

It's worth mentioning that a bot could very easily enter this area immediately after spawning, This could be fixed by using a larger air-gap, though I would avoid doing a straight 5x5 area and instead clip the corners to increase the chance of getting a a valid spawn point e.g.
```
  □ □ □ 
□ □ □ □ □
□ □ @ □ □
□ □ □ □ □
  □ □ □
```