### PR TITLE
Fix to is_pos_legal to stop bots spawning on the same tile

### DIFF
--- a/app/crates/kartoffels-world/src/bots/systems/spawn.rs
+++ b/app/crates/kartoffels-world/src/bots/systems/spawn.rs
@@ -151,7 +151,7 @@ fn is_pos_legal(
         return false;
     }
     if !check_neighborhood {
-        return true;
+        return bots.lookup_at(pos).is_none();
     }
     for x in -1..=1 {
         for y in -1..=1 {


### PR DESCRIPTION
Just noticed whilst trying to debug some other stuff to do with AliveBots that the spawning function allowed for this
this is a necessary change since the hashmap `AliveBots.pos_to_id` means that two bots on the same position could break bot lookup code

I must have missed this when removing the double check of the actual position